### PR TITLE
Add network-ee-tox-ansible-builder job

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -1,5 +1,24 @@
 ---
 - job:
+    name: network-ee-tox-ansible-builder
+    parent: ansible-buildset-registry-consumer
+    timeout: 3600
+    vars:
+      container_command: podman
+
+- job:
+    name: network-ee-tox-ansible-builder
+    parent: tox
+    requires:
+      - ansible-runner-container-image
+    required-projects:
+      - github.com/ansible/ansible-builder
+    nodeset: ubuntu-bionic-1vcpu
+    vars:
+      tox_envlist: ansible-builder
+      tox_install_siblings: false
+
+- job:
     name: network-ee-build-container-image
     parent: ansible-build-container-image
     description: Build network-ee container image

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -3,9 +3,11 @@
     check:
       jobs:
         - network-ee-build-container-image
+        - network-ee-tox-ansible-builder
     gate:
       jobs:
         - network-ee-build-container-image
+        - network-ee-tox-ansible-builder
     post:
       jobs:
         - network-ee-upload-container-image:

--- a/tools/check_ansible_builder_changed.sh
+++ b/tools/check_ansible_builder_changed.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+DIRTY=$(git status --porcelain | wc -l)
+if [ "$DIRTY" -ne 0 ]; then
+    echo "ERROR: ansible-builder context is out of date, please re-run: "
+    echo ""
+    echo "    tox -ebuild"
+    echo ""
+    echo "And commit changes."
+    exit 1
+fi
+

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,9 @@ passenv =
 commands =
   ansible-builder build -v3 -c . -f tools/execution-environment.yaml -t quay.io/ansible/network-ee
 
-[testenv:venv]
-setenv =
-  ANSIBLE_CALLBACK_PLUGINS = {envsitepackagesdir}/ara/plugins/callbacks
-commands = {posargs}
+[testenv:ansible-builder]
+passenv =
+  {[testenv:build]passenv}
+commands =
+  {[testenv:build]commands}
+  {toxinidir}/tools/check_ansible_builder_changed.sh


### PR DESCRIPTION
Validate we can build ansible/network-ee using ansible-builder.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>