### PR TITLE
Add extra info when tox -eansible-builder fails

### DIFF
--- a/tools/check_ansible_builder_changed.sh
+++ b/tools/check_ansible_builder_changed.sh
@@ -7,6 +7,8 @@ if [ "$DIRTY" -ne 0 ]; then
     echo "    tox -ebuild"
     echo ""
     echo "And commit changes."
+    git status
+    git diff
     exit 1
 fi
 


### PR DESCRIPTION
Give more debug info to a user when validation fails.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>