### PR TITLE
Changes needed for latest ansible-builder

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ansible/ansible-runner:devel as builder
+FROM quay.io/ansible/ansible-runner:devel as galaxy
 
 ADD requirements.yml /build/
 
@@ -7,10 +7,17 @@ RUN ansible-galaxy collection install -r /build/requirements.yml --collections-p
 
 RUN mkdir -p /usr/share/ansible/roles /usr/share/ansible/collections
 
+FROM quay.io/ansible/python-builder:latest as builder
+
+ADD requirements_combined.txt /tmp/src/requirements.txt
+ADD bindep_combined.txt /tmp/src/bindep.txt
+RUN assemble
+
 FROM quay.io/ansible/ansible-runner:devel
 
-COPY --from=builder /usr/share/ansible/roles /usr/share/ansible/roles
-COPY --from=builder /usr/share/ansible/collections /usr/share/ansible/collections
 
-ADD requirements_combined.txt /build/
-RUN pip3 install --upgrade -r /build/requirements_combined.txt
+COPY --from=galaxy /usr/share/ansible/roles /usr/share/ansible/roles
+COPY --from=galaxy /usr/share/ansible/collections /usr/share/ansible/collections
+
+COPY --from=builder /output/ /output/
+RUN /output/install-from-bindep && rm -rf /output/wheels


### PR DESCRIPTION
This switch network-ee to use latest code from ansible-builder. Which
includes moving to centos-8 and multi-stage builds.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>