### PR TITLE
Create network-ee:stable-2.9-latest image

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -20,10 +20,17 @@
       tox_package_name: "{{ zuul.project.short_name }}"
 
 - job:
+    name: network-ee-container-image-base
+    abstract: true
+    timeout: 3600
+    requires:
+      - python-builder-container-image
+    nodeset: ubuntu-bionic-4vcpu
+
+- job:
     name: network-ee-build-container-image
     parent: ansible-build-container-image
-    description: Build network-ee container image
-    timeout: 3600
+    description: Build network-ee container images
     provides:
       - network-ee-container-image
       - network-ee-sanity-tests-container-image
@@ -31,9 +38,7 @@
       - network-ee-unit-tests-container-image
     requires:
       - ansible-runner-container-image
-      - python-builder-container-image
-    nodeset: ubuntu-bionic-4vcpu
-    vars: &network_ee_vars
+    vars: &network_ee_image_vars
       container_images: &network_ee_container_images
         - context: .
           registry: quay.io
@@ -60,10 +65,54 @@
       docker_images: *network_ee_container_images
 
 - job:
+    name: network-ee-build-container-image
+    parent: network-ee-container-image-base
+
+- job:
+    name: network-ee-build-container-image-stable-2.9
+    parent: ansible-build-container-image
+    description: Build network-ee stable-2.9 container images
+    provides:
+      - network-ee-stable-2.9-container-image
+      - network-ee-sanity-tests-stable-2.9-container-image
+      - network-ee-tests-stable-2.9-container-image
+      - network-ee-unit-tests-stable-2.9-container-image
+    requires:
+      - ansible-runner-stable-2.9-container-image
+    vars: &network_ee_stable_2_9_image_vars
+      container_images: &network_ee_container_images_stable_2_9
+        - context: .
+          build_args:
+            - ANSIBLE_RUNNER_IMAGE=quay.io/ansible/ansible-runner:stable-2.9-devel
+          registry: quay.io
+          repository: quay.io/ansible/network-ee
+          tags:
+            &imagetag_stable_2_9 ['stable-2.9-latest']
+        - context: tests
+          registry: quay.io
+          repository: quay.io/ansible/network-ee-tests
+          target: network-ee-tests
+          tags: *imagetag_stable_2_9
+        - context: tests
+          registry: quay.io
+          repository: quay.io/ansible/network-ee-sanity-tests
+          target: network-ee-sanity-tests
+          tags: *imagetag_stable_2_9
+        - context: tests
+          registry: quay.io
+          repository: quay.io/ansible/network-ee-unit-tests
+          target: network-ee-unit-tests
+          tags: *imagetag_stable_2_9
+      docker_images: *network_ee_container_images_stable_2_9
+
+- job:
+    name: network-ee-build-container-image-stable-2.9
+    parent: network-ee-container-image-base
+
+- job:
     name: network-ee-upload-container-image
     parent: ansible-upload-container-image
-    description: Build network-ee container image and upload to quay.io
-    timeout: 3600
+    description: Build network-ee container images and upload to quay.io
     provides:
       - network-ee-container-image
       - network-ee-sanity-tests-container-image
@@ -71,6 +120,25 @@
       - network-ee-unit-tests-container-image
     requires:
       - ansible-runner-container-image
-      - python-builder-container-image
-    nodeset: ubuntu-bionic-4vcpu
-    vars: *network_ee_vars
+    vars: *network_ee_image_vars
+
+- job:
+    name: network-ee-upload-container-image
+    parent: network-ee-container-image-base
+
+- job:
+    name: network-ee-upload-container-image-stable-2.9
+    parent: ansible-upload-container-image
+    description: Build network-ee stable-2.9 container images and upload to quay.io
+    provides:
+      - network-ee-stable-2.9-container-image
+      - network-ee-sanity-tests-stable-2.9-container-image
+      - network-ee-tests-stable-2.9-container-image
+      - network-ee-unit-tests-stable-2.9-container-image
+    requires:
+      - ansible-runner-stable-2.9-container-image
+    vars: *network_ee_stable_2_9_image_vars
+
+- job:
+    name: network-ee-upload-container-image-stable-2.9
+    parent: network-ee-container-image-base

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -3,18 +3,26 @@
     check:
       jobs:
         - network-ee-build-container-image
+        - network-ee-build-container-image-stable-2.9
         - network-ee-tox-ansible-builder
     gate:
       jobs:
         - network-ee-build-container-image
+        - network-ee-build-container-image-stable-2.9
         - network-ee-tox-ansible-builder
     post:
       jobs:
         - network-ee-upload-container-image:
             vars:
               upload_container_image_promote: false
+        - network-ee-upload-container-image-stable-2.9:
+            vars:
+              upload_container_image_promote: false
     periodic:
       jobs:
         - network-ee-upload-container-image:
+            vars:
+              upload_container_image_promote: false
+        - network-ee-upload-container-image-stable-2.9:
             vars:
               upload_container_image_promote: false

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,7 @@
-FROM quay.io/ansible/ansible-runner:devel as galaxy
+ARG ANSIBLE_RUNNER_IMAGE=quay.io/ansible/ansible-runner:devel
+ARG PYTHON_BUILDER_IMAGE=quay.io/ansible/python-builder:latest
+
+FROM $ANSIBLE_RUNNER_IMAGE as galaxy
 
 ADD _build/requirements.yml /build/_build/requirements.yml
 
@@ -7,14 +10,12 @@ RUN ansible-galaxy collection install -r /build/_build/requirements.yml --collec
 
 RUN mkdir -p /usr/share/ansible/roles /usr/share/ansible/collections
 
-FROM quay.io/ansible/python-builder:latest as builder
-
+FROM $PYTHON_BUILDER_IMAGE as builder
 ADD _build/requirements_combined.txt /tmp/src/requirements.txt
 ADD _build/bindep_combined.txt /tmp/src/bindep.txt
 RUN assemble
 
-FROM quay.io/ansible/ansible-runner:devel
-
+FROM $ANSIBLE_RUNNER_IMAGE
 
 COPY --from=galaxy /usr/share/ansible/roles /usr/share/ansible/roles
 COPY --from=galaxy /usr/share/ansible/collections /usr/share/ansible/collections


### PR DESCRIPTION
Bring online the ability to create stable-2.9 images too.

Depends-On: https://github.com/ansible/ansible-builder/pull/167
Depends-On: https://github.com/ansible/network-ee/pull/18
Signed-off-by: Paul Belanger <pabelanger@redhat.com>