### PR TITLE
Add zuul siblings support for ansible-pylibssh

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -28,11 +28,15 @@
     requires:
       - ansible-runner-container-image
       - python-builder-container-image
+    required-projects:
+      - github.com/ansible/pylibssh
     vars: &vars
       container_images: &container_images
         - context: .
           registry: quay.io
           repository: quay.io/ansible/network-ee
+          siblings:
+            - github.com/ansible/pylibssh
           tags:
             # If zuul.tag is defined: [ '3', '3.19', '3.19.0' ].  Only works for 3-component tags.
             # Otherwise: ['latest']

--- a/Containerfile
+++ b/Containerfile
@@ -9,6 +9,8 @@ RUN mkdir -p /usr/share/ansible/roles /usr/share/ansible/collections
 
 FROM quay.io/ansible/python-builder:latest as builder
 
+COPY . /tmp/src
+
 ADD _build/requirements_combined.txt /tmp/src/requirements.txt
 ADD _build/bindep_combined.txt /tmp/src/bindep.txt
 RUN assemble


### PR DESCRIPTION
This will allow us to do cross project testing with pylibssh.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>