### PR TITLE
Create network-ee-test images

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -23,13 +23,18 @@
     name: network-ee-build-container-image
     parent: ansible-build-container-image
     description: Build network-ee container image
-    timeout: 2700
-    provides: network-ee-container-image
+    timeout: 3600
+    provides:
+      - network-ee-container-image
+      - network-ee-sanity-tests-container-image
+      - network-ee-tests-container-image
+      - network-ee-unit-tests-container-image
     requires:
       - ansible-runner-container-image
       - python-builder-container-image
-    vars: &vars
-      container_images: &container_images
+    nodeset: ubuntu-bionic-4vcpu
+    vars: &network_ee_vars
+      container_images: &network_ee_container_images
         - context: .
           registry: quay.io
           repository: quay.io/ansible/network-ee
@@ -37,15 +42,35 @@
             # If zuul.tag is defined: [ '3', '3.19', '3.19.0' ].  Only works for 3-component tags.
             # Otherwise: ['latest']
             &imagetag "{{ zuul.tag is defined | ternary([zuul.get('tag', '').split('.')[0], '.'.join(zuul.get('tag', '').split('.')[:2]), zuul.get('tag', '')], ['latest']) }}"
-      docker_images: *container_images
+        - context: tests
+          registry: quay.io
+          repository: quay.io/ansible/network-ee-tests
+          target: network-ee-tests
+          tags: *imagetag
+        - context: tests
+          registry: quay.io
+          repository: quay.io/ansible/network-ee-sanity-tests
+          target: network-ee-sanity-tests
+          tags: *imagetag
+        - context: tests
+          registry: quay.io
+          repository: quay.io/ansible/network-ee-unit-tests
+          target: network-ee-sanity-tests
+          tags: *imagetag
+      docker_images: *network_ee_container_images
 
 - job:
     name: network-ee-upload-container-image
     parent: ansible-upload-container-image
     description: Build network-ee container image and upload to quay.io
-    timeout: 2700
-    provides: network-ee-container-image
+    timeout: 3600
+    provides:
+      - network-ee-container-image
+      - network-ee-sanity-tests-container-image
+      - network-ee-tests-container-image
+      - network-ee-unit-tests-container-image
     requires:
       - ansible-runner-container-image
       - python-builder-container-image
-    vars: *vars
+    nodeset: ubuntu-bionic-4vcpu
+    vars: *network_ee_vars

--- a/tests/Containerfile
+++ b/tests/Containerfile
@@ -1,0 +1,21 @@
+FROM quay.io/ansible/python-builder:latest as builder
+# =============================================================================
+
+ARG ZUUL_SIBLINGS=""
+COPY . /tmp/src
+RUN assemble
+
+FROM quay.io/ansible/network-ee:latest as network-ee-tests
+# =============================================================================
+
+COPY --from=builder /output/ /output/
+RUN /output/install-from-bindep \
+  && rm -rf /output/
+
+FROM network-ee-tests as network-ee-sanity-tests
+# =============================================================================
+CMD ["ansible-test", "sanity", "--python=3.8"]
+
+FROM network-ee-tests as network-ee-unit-tests
+# =============================================================================
+CMD ["ansible-test", "units", "--python=3.8"]

--- a/tests/bindep.txt
+++ b/tests/bindep.txt
@@ -1,0 +1,7 @@
+# This is a cross-platform list tracking distribution packages needed by tests;
+# see https://docs.openstack.org/infra/bindep/ for additional information.
+
+python38-packaging [platform:centos-8]
+python38-pyparsing [platform:centos-8]
+python38-six [platform:centos-8]
+python38-yaml [platform:centos-8]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,9 @@
+coverage==4.5.4
+flake8
+pylint
+rstcheck
+voluptuous
+yamllint
+
+# units
+pytest-xdist


### PR DESCRIPTION
This will create 3 new test images to be used in our CI. A top-level
test image, then sanity and unit test images.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>