### PR TITLE
Use same nodeset for network-ee-tox-ansible-builder

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -14,7 +14,7 @@
       - python-builder-container-image
     required-projects:
       - github.com/ansible/ansible-builder
-    nodeset: ubuntu-bionic-1vcpu
+    nodeset: ubuntu-bionic-4vcpu
     vars:
       tox_envlist: ansible-builder
       tox_package_name: "{{ zuul.project.short_name }}"


### PR DESCRIPTION
Now all container jobs are using the same nodeset.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>