### PR TITLE
Use pre-release network collections

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -41,6 +41,8 @@
     vars: &network_ee_image_vars
       container_images: &network_ee_container_images
         - context: .
+          build_args:
+            - ANSIBLE_GALAXY_CLI_COLLECTION_OPTS=--pre
           registry: quay.io
           repository: quay.io/ansible/network-ee
           tags:

--- a/Containerfile
+++ b/Containerfile
@@ -3,12 +3,11 @@ ARG PYTHON_BUILDER_IMAGE=quay.io/ansible/python-builder:latest
 
 FROM $ANSIBLE_RUNNER_IMAGE as galaxy
 
+ARG ANSIBLE_GALAXY_CLI_COLLECTION_OPTS=
 ADD _build/requirements.yml /build/_build/requirements.yml
 
 RUN ansible-galaxy role install -r /build/_build/requirements.yml --roles-path /usr/share/ansible/roles
-RUN ansible-galaxy collection install -r /build/_build/requirements.yml --collections-path /usr/share/ansible/collections
-
-RUN mkdir -p /usr/share/ansible/roles /usr/share/ansible/collections
+RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r /build/_build/requirements.yml --collections-path /usr/share/ansible/collections
 
 FROM $PYTHON_BUILDER_IMAGE as builder
 ADD _build/requirements_combined.txt /tmp/src/requirements.txt
@@ -17,8 +16,7 @@ RUN assemble
 
 FROM $ANSIBLE_RUNNER_IMAGE
 
-COPY --from=galaxy /usr/share/ansible/roles /usr/share/ansible/roles
-COPY --from=galaxy /usr/share/ansible/collections /usr/share/ansible/collections
+COPY --from=galaxy /usr/share/ansible /usr/share/ansible
 
 COPY --from=builder /output/ /output/
 RUN /output/install-from-bindep && rm -rf /output/wheels


### PR DESCRIPTION
We always want to use the latest version of collections publish to
galaxy.

Depends-On: https://github.com/ansible/ansible-builder/pull/173
Signed-off-by: Paul Belanger <pabelanger@redhat.com>