### PR TITLE
Setup zuul_work_dir for other jobs to run jobs

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -26,6 +26,8 @@
     requires:
       - python-builder-container-image
     nodeset: ubuntu-bionic-4vcpu
+    vars:
+      zuul_work_dir: "{{ zuul.projects['github.com/ansible/network-ee'].src_dir }}"
 
 - job:
     name: network-ee-build-container-image


### PR DESCRIPTION
This allows other projects, to run our jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>