### PR TITLE
Rename stable-2.9-latest tag to stable-2.9

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -91,7 +91,7 @@
           registry: quay.io
           repository: quay.io/ansible/network-ee
           tags:
-            &imagetag_stable_2_9 ['stable-2.9-latest']
+            &imagetag_stable_2_9 ['stable-2.9']
         - context: tests
           registry: quay.io
           repository: quay.io/ansible/network-ee-tests


### PR DESCRIPTION
There is no need to say 'latest', as we always package the latest
stable-2.9 branch.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>