### PR TITLE
Add 'ansible.utils' python dependencies

### DIFF
--- a/_build/requirements_combined.txt
+++ b/_build/requirements_combined.txt
@@ -4,6 +4,9 @@ ncclient  # from collection ansible.netcommon,cisco.iosxr,junipernetworks.junos
 selectors2  # from collection ansible.netcommon
 netaddr  # from collection ansible.netcommon
 paramiko  # from collection ansible.netcommon,arista.eos,cisco.ios,cisco.iosxr,cisco.nxos,junipernetworks.junos,vyos.vyos
-xmltodict  # from collection ansible.netcommon,junipernetworks.junos
+xmltodict  # from collection ansible.netcommon,junipernetworks.junos,user
 lxml  # from collection cisco.iosxr
 scp  # from collection cisco.nxos,junipernetworks.junos
+jsonschema  # from collection user
+textfsm  # from collection user
+ttp  # from collection user

--- a/tools/execution-environment.yaml
+++ b/tools/execution-environment.yaml
@@ -2,3 +2,4 @@
 version: 1
 dependencies:
   galaxy: requirements.yaml
+  python: requirements.txt

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,4 @@
+jsonschema
+textfsm
+ttp
+xmltodict


### PR DESCRIPTION
We currently have a chicken and egg issue with requirements. There is no
way to add a new python dependency, without first releasing a
collection. Which, makes it difficult to properly test, before
releasing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>