### PR TITLE
Add irrelevant-files for cachito

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -3,6 +3,8 @@
     name: network-ee-tox-ansible-builder
     parent: ansible-buildset-registry-consumer
     timeout: 5400
+    irrelevant-files:
+      - tools/cachito/.*
     vars:
       container_command: podman
 
@@ -28,6 +30,8 @@
     requires:
       - python-builder-container-image
     nodeset: ubuntu-bionic-4vcpu
+    irrelevant-files:
+      - tools/cachito/.*
     vars:
       zuul_work_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/network-ee'].src_dir }}"
 


### PR DESCRIPTION
We don't actually need to test containers, as these files are not used.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>