### PR TITLE
Revert back to including network collections

### DIFF
--- a/_build/requirements.yml
+++ b/_build/requirements.yml
@@ -1,7 +1,17 @@
 ---
 collections:
+  - name: ansible.netcommon
   - name: ansible.network
   - name: ansible.posix
+  - name: ansible.utils
+  - name: arista.eos
   - name: cisco.asa
+  - name: cisco.ios
+  - name: cisco.iosxr
+  - name: cisco.nxos
   - name: cloud.common
+  - name: frr.frr
+  - name: junipernetworks.junos
+  - name: openvswitch.openvswitch
   - name: servicenow.itsm
+  - name: vyos.vyos

--- a/tools/requirements.yaml
+++ b/tools/requirements.yaml
@@ -1,7 +1,17 @@
 ---
 collections:
+  - name: ansible.netcommon
   - name: ansible.network
   - name: ansible.posix
+  - name: ansible.utils
+  - name: arista.eos
   - name: cisco.asa
+  - name: cisco.ios
+  - name: cisco.iosxr
+  - name: cisco.nxos
   - name: cloud.common
+  - name: frr.frr
+  - name: junipernetworks.junos
+  - name: openvswitch.openvswitch
   - name: servicenow.itsm
+  - name: vyos.vyos


### PR DESCRIPTION
Because we modify the requirements.yaml file in CI, to use pre-merged
network collections. We don't want to download that content from galaxy,
but rather use the collection we build from git.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>