### PR TITLE
Add network-ee container jobs to integrated queue

### DIFF
--- a/.zuul.d/project-templates.yaml
+++ b/.zuul.d/project-templates.yaml
@@ -30,4 +30,5 @@
         - network-ee-build-container-image-stable-2.10
         - network-ee-build-container-image-stable-2.11
     gate:
+      queue: integrated
       jobs: *jobs


### PR DESCRIPTION
As we have more projects merging changes for execution environments
there is more chances for things to break.  Lets put everything into the
same shared queue.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>