### PR TITLE
Revert "Add network-ee container jobs to integrated queue"

### DIFF
--- a/.zuul.d/project-templates.yaml
+++ b/.zuul.d/project-templates.yaml
@@ -32,5 +32,4 @@
         - network-ee-build-container-image-stable-2.10
         - network-ee-build-container-image-stable-2.11
     gate:
-      queue: integrated
       jobs: *jobs


### PR DESCRIPTION
Actually, don't force this for now. Until we can get a better handle on
aws testing.

This reverts commit d1786f80a5ac4cf61bc529721515d4e2f04285b1.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>