### PR TITLE
Experiment with ansible-buildset-registry job

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -37,6 +37,7 @@
     abstract: true
     pre-run: playbooks/network-ee-build-container-image-base/pre.yaml
     dependencies:
+      - ansible-buildset-registry
       - build-ansible-collection
 
 - job:

--- a/.zuul.d/project-templates.yaml
+++ b/.zuul.d/project-templates.yaml
@@ -27,6 +27,7 @@
               - name: github.com/ansible-collections/trendmicro.deepsec
               - name: github.com/ansible-collections/vmware.vmware_rest
               - name: github.com/ansible-collections/vyos.vyos
+        - ansible-buildset-registry
         - network-ee-build-container-image
         - network-ee-build-container-image-stable-2.9
         - network-ee-build-container-image-stable-2.10


### PR DESCRIPTION
In an effort to save capacity, just a single buildset-registry for
container builds.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1033
Signed-off-by: Paul Belanger <pabelanger@redhat.com>