### PR TITLE
Add cisco.ios inventory file

### DIFF
--- a/tests/integration/inventories/ios.yaml
+++ b/tests/integration/inventories/ios.yaml
@@ -1,0 +1,16 @@
+---
+appliance:
+  hosts:
+    ios:
+      ansible_host: ios.example.org
+      ansible_user: zuul
+  vars:
+    ansible_become: true
+    ansible_become_method: ansible.netcommon.enable
+    ansible_connection: ansible.netcommon.network_cli
+    ansible_network_os: cisco.ios.ios
+    # NOTE(pabelanger): With stable-2.9 / stable-2.11 we need to force
+    # /usr/bin/python3.8 and not discover /usr/libexec/platform-python (python3.6)
+    # ansible_python_interpreter: /usr/bin/python3.8
+    collection_name: ios
+    collection_namespace: cisco

--- a/tests/integration/inventories/vyos.yaml
+++ b/tests/integration/inventories/vyos.yaml
@@ -1,9 +1,4 @@
 ---
-all:
-  hosts:
-    localhost:
-      ansible_connection: local
-      ansible_python_interpreter: /usr/bin/python3.8
 appliance:
   hosts:
     vyos:


### PR DESCRIPTION
This will be used by cisco.ios network-ee-integration-tests jobs.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1050
Signed-off-by: Paul Belanger <pabelanger@redhat.com>