### PR TITLE
Add support for local test-requirements.txt file

### DIFF
--- a/tests/Containerfile
+++ b/tests/Containerfile
@@ -22,6 +22,7 @@ FROM quay.io/ansible/python-builder:latest as builder
 ARG ZUUL_SIBLINGS=""
 COPY --from=requirements /tmp/src /tmp/src
 COPY . /tmp/src
+RUN cat /tmp/src/test-requirements.txt | sort -u >> /tmp/src/requirements.txt
 RUN assemble
 
 FROM $NETWORK_EE_IMAGE

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -1,0 +1,1 @@
+placebo


### PR DESCRIPTION
This is to allow amazon.aws jobs to function.  However, this highlights
the needs of per collection test images / global constraint files.

Something I hopefully will work on shortly.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>