### PR TITLE
Switch to centos-8-stream for jobs

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -16,7 +16,7 @@
       - ansible-builder-container-image
     required-projects:
       - github.com/ansible/ansible-builder
-    nodeset: ubuntu-bionic-4vcpu
+    nodeset: centos-8-stream
     vars:
       tox_envlist: ansible-builder
       tox_package_name: "{{ zuul.project.short_name }}"
@@ -29,7 +29,7 @@
       - github.com/ansible/network-ee
     requires:
       - ansible-builder-container-image
-    nodeset: ubuntu-bionic-4vcpu
+    nodeset: centos-8-stream
     vars:
       zuul_work_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/network-ee'].src_dir }}"
 

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# NOTE(pabelanger): Default to pip3, when possible this is becaue python2
-# support is EOL.
-PIP=$(command -v pip3) || PIP=$(command -v pip2)
-
-# NOTE(pabelanger): Tox on centos-7 is old, so upgrade it across all distros
-# to the latest version
-sudo $PIP install -U tox


### PR DESCRIPTION
This should get us a little closer to RHEL based testing.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1048
Depends-On: https://github.com/ansible/network-ee/pull/107
Signed-off-by: Paul Belanger <pabelanger@redhat.com>