### PR TITLE
Depend on ansible-buildset-registry for tox build job

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -2,6 +2,8 @@
 - job:
     name: network-ee-tox-ansible-builder
     parent: ansible-buildset-registry-consumer
+    dependencies:
+      - ansible-buildset-registry
     timeout: 5400
     vars:
       container_command: podman


### PR DESCRIPTION
This should make our job a little faster, and drop the docker
dependency.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>