### PR TITLE
Add dependency for ansible-buildset-registry

### DIFF
--- a/.zuul.d/project-templates.yaml
+++ b/.zuul.d/project-templates.yaml
@@ -27,7 +27,9 @@
               - name: github.com/ansible-collections/trendmicro.deepsec
               - name: github.com/ansible-collections/vmware.vmware_rest
               - name: github.com/ansible-collections/vyos.vyos
-        - ansible-buildset-registry
+        - ansible-buildset-registry:
+            dependencies:
+              - build-ansible-collection
         - network-ee-build-container-image
         - network-ee-build-container-image-stable-2.9
         - network-ee-build-container-image-stable-2.10


### PR DESCRIPTION
When things are busy, we don't want to bring online this node until
we've first build the tarballs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>