### PR TITLE
Add support for .zuul-repos.d

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -15,8 +15,7 @@ FROM $EE_BUILDER_IMAGE as builder
 
 COPY --from=galaxy /usr/share/ansible /usr/share/ansible
 
-ADD _build/requirements.txt requirements.txt
-RUN ansible-builder introspect --sanitize --user-pip=requirements.txt --write-bindep=/tmp/src/bindep.txt --write-pip=/tmp/src/requirements.txt
+RUN ansible-builder introspect --sanitize --write-bindep=/tmp/src/bindep.txt --write-pip=/tmp/src/requirements.txt
 RUN assemble
 
 FROM $EE_BASE_IMAGE

--- a/tools/execution-environment.yaml
+++ b/tools/execution-environment.yaml
@@ -5,4 +5,3 @@ build_arg_defaults:
 
 dependencies:
   galaxy: requirements.yaml
-  python: requirements.txt


### PR DESCRIPTION
This will use vexxhost mirrors for our container jobs.

Depends-On: https://github.com/ansible/ansible-builder/pull/272
Signed-off-by: Paul Belanger <pabelanger@redhat.com>