### PR TITLE
Add back python-builder-container-image

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -29,6 +29,7 @@
       - github.com/ansible/network-ee
     requires:
       - ansible-builder-container-image
+      - python-builder-container-image
     nodeset: centos-8-stream
     vars:
       zuul_work_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/network-ee'].src_dir }}"


### PR DESCRIPTION
Our network-ee-tests images need this image.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>