### PR TITLE
Apply ANSIBLE_ROLES_PATH for testing

### DIFF
--- a/tests/integration/playbooks/include_role.yaml
+++ b/tests/integration/playbooks/include_role.yaml
@@ -4,6 +4,9 @@
     - name: Run target role
       include_role:
         name: "{{ item }}"
+        apply:
+          environment:
+            ANSIBLE_ROLES_PATH: "{{ integration_tests_path }}"
 
   rescue:
     - name: Report target failure


### PR DESCRIPTION
This allows us to use roles like prepare_vyos_tests, which need to run
inside our target roles.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>