### PR TITLE
Enable FIPS mode for integration testing

### DIFF
--- a/.zuul.d/integration-jobs.yaml
+++ b/.zuul.d/integration-jobs.yaml
@@ -11,6 +11,7 @@
     vars:
       test_ansible_network_cli_ssh_type: paramiko
       test_ansible_ssh_private_key_file: ~/.ssh/id_rsa
+      test_fips_mode: true
 
 # =============================================================================
 - job:

--- a/playbooks/network-ee-integration-tests/pre.yaml
+++ b/playbooks/network-ee-integration-tests/pre.yaml
@@ -3,6 +3,12 @@
   vars:
     _hosts_dict: {}
   tasks:
+    - name: Enable FIPS mode
+      include_role:
+        name: enable-fips
+      when:
+        - test_fips_mode | bool
+
     - name: Ensure python3.8 is present
       become: true
       package:

--- a/tests/integration/playbooks/site.yaml
+++ b/tests/integration/playbooks/site.yaml
@@ -16,12 +16,10 @@
         recurse: false
       register: _targets
       delegate_to: localhost
-      no_log: true
 
     - name: Format integration targets
       set_fact:
         _integration_targets: "{{ _targets.files | map(attribute='path') | list | sort }}"
-      no_log: true
 
     - name: Report missing integration targets
       fail:


### PR DESCRIPTION
By default, we should test with FIPs mode. And collections that don't
want or cannot support it, should set test_fips_mode: false.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>