### PR TITLE
Drop ansible_become from cisco.ios testing

### DIFF
--- a/tests/integration/inventories/ios.yaml
+++ b/tests/integration/inventories/ios.yaml
@@ -5,7 +5,6 @@ appliance:
       ansible_host: ios.example.org
       ansible_user: zuul
   vars:
-    ansible_become: true
     ansible_become_method: ansible.netcommon.enable
     ansible_connection: ansible.netcommon.network_cli
     ansible_network_os: cisco.ios.ios


### PR DESCRIPTION
We should configure an enable password for testing!

Signed-off-by: Paul Belanger <pabelanger@redhat.com>