### PR TITLE
Revert "Pin Pytest 6.2.0"

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,1 @@
 yamllint
-pytest==6.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 envlist = linters
 
 [testenv]
-basepython = python3.10
+basepython = python3.8
 install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1401

This reverts commit 26604d4836aade226f60f07727776b4eb0c0b092.

pytest 7.1.1 has been released with a fix for the fixture problem.

See: https://github.com/pytest-dev/pytest/issues/9767
