### PR TITLE
ansible-navigator.yaml: follow the recent key renaming upstream

### DIFF
--- a/tests/integration/ansible-navigator.yaml
+++ b/tests/integration/ansible-navigator.yaml
@@ -3,8 +3,9 @@ ansible-navigator:
   ansible:
     cmdline: -vvvv
     config: ansible.cfg
-    inventories:
-      - inventories/hosts.yaml
+    inventory:
+      paths:
+        - inventories/hosts.yaml
     playbook: playbooks/site.yaml
   app: run
   color:


### PR DESCRIPTION
ansible-navigator has recently renamed the inventories key.

This address the following error:

    [0;31m[ERROR]: In 'ansible-navigator.ansible': Additional properties are not allowed ('inventories' was unexpected).[0m