### PR TITLE
ansible-navigator: remove deprecated keys

### DIFF
--- a/tests/integration/ansible-navigator.yaml
+++ b/tests/integration/ansible-navigator.yaml
@@ -2,16 +2,20 @@
 ansible-navigator:
   ansible:
     cmdline: -vvvv
-    config: ansible.cfg
-    inventories:
-      - inventories/hosts.yaml
-    playbook: playbooks/site.yaml
+    config:
+      path: ansible.cfg
+    inventory:
+      paths:
+        - inventories/hosts.yaml
+    playbook:
+      path: playbooks/site.yaml
   app: run
   color:
     enable: false
   execution-environment:
     image: quay.io/ansible/network-ee:latest
-    pull-policy: missing
+    pull:
+      policy: never
   logging:
     file: logs/ansible-navigator.log
     level: debug


### PR DESCRIPTION
https://ansible-navigator.readthedocs.io/en/latest/changelog/#backward-incompatible-changes
