### PR TITLE
overwrite the yum repository configuration

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,6 +8,9 @@ USER root
 ADD _build /build
 WORKDIR /build
 
+RUN rm /etc/yum.repos.d/*.repo
+COPY etc/yum.repos.d/centos.repo /etc/yum.repos.d/centos.repo
+RUN dnf distro-sync -y
 RUN ansible-galaxy role install -r requirements.yml --roles-path /usr/share/ansible/roles
 RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r requirements.yml --collections-path /usr/share/ansible/collections
 

--- a/etc/yum.repos.d/centos.repo
+++ b/etc/yum.repos.d/centos.repo
@@ -1,0 +1,35 @@
+[appstream]
+name=CentOS Stream $releasever - AppStream
+baseurl=http://centos.mirror.iweb.com/$stream/AppStream/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+
+[baseos]
+name=CentOS Stream $releasever - BaseOS
+baseurl=http://centos.mirror.iweb.com/$stream/BaseOS/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+
+#[extras]
+#name=CentOS Stream $releasever - Extras
+#baseurl=http://centos.mirror.iweb.com/$stream/extras/$basearch/os/
+#gpgcheck=1
+#enabled=1
+#gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+#
+#[extras-common]
+#name=CentOS Stream $releasever - Extras common packages
+#mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras-extras-common
+#baseurl=http://centos.mirror.iweb.com/$stream/extras/$basearch/extras-common/
+#gpgcheck=1
+#enabled=1
+#gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Extras
+
+[powertools]
+name=CentOS Stream $releasever - PowerTools
+baseurl=http://centos.mirror.iweb.com/$stream/PowerTools/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial


### PR DESCRIPTION
This to be able to address problem like this:

    + /usr/bin/dnf update -y
    CentOS Stream 8 - AppStream                     6.7 MB/s |  21 MB     00:03
    CentOS Stream 8 - BaseOS                        2.9 MB/s |  20 MB     00:07
    CentOS Stream 8 - Extras                        120 kB/s |  18 kB     00:00
    CentOS Stream 8 - PowerTools                    3.9 MB/s | 4.4 MB     00:01
    Extra Packages for Enterprise Linux Modular 8 - 960 kB/s | 1.0 MB     00:01
    Error:
     Problem: package centos-stream-repos-8-4.el8.noarch requires centos-gpg-keys = 1:8-4.el8, but none of the providers can be installed
      - cannot install both centos-gpg-keys-1:8-5.el8.noarch and centos-gpg-keys-1:8-4.el8.noarch
      - cannot install the best update candidate for package centos-stream-repos-8-4.el8.noarch
      - cannot install the best update candidate for package centos-gpg-keys-1:8-4.el8.noarch
    (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
