### PR TITLE
don't continue in case of failure

### DIFF
--- a/tests/integration/playbooks/include_role.yaml
+++ b/tests/integration/playbooks/include_role.yaml
@@ -1,14 +1,7 @@
 ---
-- name: include roles
-  block:
-    - name: Run target role
-      include_role:
-        name: "{{ item }}"
-
-  rescue:
-    - name: Report target failure
-      set_fact:
-        integration_target_failures: "{{ integration_target_failures + [item.split('/')[-1]] }}"
+- name: Run target role
+  include_role:
+    name: "{{ item }}"
 
 - name: Clear gathered facts
   ansible.builtin.meta: clear_facts

--- a/tests/integration/playbooks/site.yaml
+++ b/tests/integration/playbooks/site.yaml
@@ -35,14 +35,3 @@
         file: include_role.yaml
       with_items:
         - "{{ _integration_targets }}"
-
-    - name: Integration tests failed
-      block:
-        - name: Show target failures
-          debug:
-            msg: "{{ integration_target_failures }}"
-
-        - name: We have a problem
-          fail:
-            msg: "One or more integration tests failed!"
-      when: integration_target_failures


### PR DESCRIPTION
It's way harder to figure out what test has failed when the
error is in the middle of 1h of log output.
